### PR TITLE
adding optional extra data field to the block format

### DIFF
--- a/server/src/block/block.ts
+++ b/server/src/block/block.ts
@@ -27,6 +27,9 @@ export type Block = {
 
   /** The previous hash of the block. A SHA-256 hash of the previous block's data. */
   previousHash: string;
+
+  /** Optional JSON data associated with the block. */
+  data?: Record<string, unknown>;
 };
 
 export const Block = {

--- a/server/src/chain/chain.test.ts
+++ b/server/src/chain/chain.test.ts
@@ -270,6 +270,84 @@ describe("Chain", () => {
     });
   });
 
+  describe("verifyIncomingBlock", () => {
+    it("Can verify and create a block with data field", () => {
+      const chain = [validChain[0]];
+      const previousBlock = chain[chain.length - 1];
+      const { hash, nonce } = Miner.findHash({
+        difficultyTarget: Difficulty.getDifficultyTargetFromChain(chain),
+        previousHash: previousBlock.hash,
+        previousTimestamp: previousBlock.timestamp,
+        player: "BOB",
+        team: "TST",
+      });
+
+      const newBlock = Chain.verifyIncomingBlock(
+        {
+          previousHash: previousBlock.hash,
+          player: "BOB",
+          team: "TST",
+          nonce,
+          hash,
+          identity: "abcdef1234567890",
+          data: { hello: "world", count: 42 },
+        },
+        chain,
+      );
+
+      expect(newBlock).toEqual(
+        expect.objectContaining({
+          hash,
+          previousHash: previousBlock.hash,
+          player: "BOB",
+          team: "TST",
+          nonce,
+          identity: "abcdef1234567890",
+          index: 1,
+          data: { hello: "world", count: 42 },
+        }),
+      );
+    });
+
+    it("Can verify and create a block without data field", () => {
+      const chain = [validChain[0]];
+      const previousBlock = chain[chain.length - 1];
+      const { hash, nonce } = Miner.findHash({
+        difficultyTarget: Difficulty.getDifficultyTargetFromChain(chain),
+        previousHash: previousBlock.hash,
+        previousTimestamp: previousBlock.timestamp,
+        player: "BOB",
+        team: "TST",
+      });
+
+      const newBlock = Chain.verifyIncomingBlock(
+        {
+          previousHash: previousBlock.hash,
+          player: "BOB",
+          team: "TST",
+          nonce,
+          hash,
+          identity: "abcdef1234567890",
+        },
+        chain,
+      );
+
+      expect(newBlock).toEqual(
+        expect.objectContaining({
+          hash,
+          previousHash: previousBlock.hash,
+          player: "BOB",
+          team: "TST",
+          nonce,
+          identity: "abcdef1234567890",
+          index: 1,
+        }),
+      );
+      // Data field should be undefined when not provided
+      expect(newBlock.data).toBeUndefined();
+    });
+  });
+
   describe("getPlayerBlocks", () => {
     it("It can get the blocks for a player", () => {
       const chain = validChain.map((block) => ({ ...block }));

--- a/server/src/chain/chain.ts
+++ b/server/src/chain/chain.ts
@@ -116,6 +116,7 @@ export const Chain = {
       nonce: number;
       hash: string;
       identity: string;
+      data?: Record<string, unknown>;
     },
     chain: Chain,
   ): Block => {
@@ -172,6 +173,7 @@ export const Chain = {
       nonce,
       index: previousBlock.index + 1,
       identity,
+      data: args.data,
     };
 
     return newBlock;

--- a/server/src/data/data.test.ts
+++ b/server/src/data/data.test.ts
@@ -242,7 +242,7 @@ describe("Data", () => {
       );
     });
 
-    it.only("Throws error when data part is not an object", () => {
+    it("Throws error when data part is not an object", () => {
       const line =
         'b13b9e5e847936705e86dd4b7799:edb8c1afbf45558223119f87365a:TIM:TST:1769230455:4138e:f77ad768fd3d3f64:6648:["array","not","object"]';
 

--- a/server/src/data/data.test.ts
+++ b/server/src/data/data.test.ts
@@ -78,6 +78,7 @@ describe("Data", () => {
         nonce: 267150,
         index: 6648,
         identity: "f77ad768fd3d3f64",
+        data: {},
       });
     });
 
@@ -94,6 +95,7 @@ describe("Data", () => {
         nonce: 267150,
         index: 6648,
         identity: "f77ad768fd3d3f64",
+        data: {},
       });
     });
 
@@ -154,7 +156,8 @@ describe("Data", () => {
       for (const block of testBlocks) {
         const stringified = Data.stringify(block);
         const parsed = Data.parse(stringified);
-        expect(parsed).toEqual(block);
+        // When parsing blocks without data, data should be set to {}
+        expect(parsed).toEqual({ ...block, data: {} });
       }
     });
 
@@ -163,6 +166,88 @@ describe("Data", () => {
 
       expect(() => Data.parse(line)).toThrow(
         "Invalid block format: expected 8 parts separated by ':', got 7",
+      );
+    });
+
+    it("Can parse a line with data (9 parts)", () => {
+      const line =
+        'b13b9e5e847936705e86dd4b7799:edb8c1afbf45558223119f87365a:TIM:TST:1769230455:4138e:f77ad768fd3d3f64:6648:{"hello":"world","count":42}';
+
+      const result = Data.parse(line);
+      expect(result).toEqual({
+        hash: "ffffb13b9e5e847936705e86dd4b7799",
+        previousHash: "ffffedb8c1afbf45558223119f87365a",
+        player: "TIM",
+        team: "TST",
+        timestamp: 1769230455,
+        nonce: 267150,
+        index: 6648,
+        identity: "f77ad768fd3d3f64",
+        data: { hello: "world", count: 42 },
+      });
+    });
+
+    it("Can stringify and parse a block with data", () => {
+      const block: Block = {
+        hash: "ffffb13b9e5e847936705e86dd4b7799",
+        previousHash: "ffffedb8c1afbf45558223119f87365a",
+        player: "TIM",
+        team: "TST",
+        timestamp: 1769230455,
+        nonce: 267150,
+        index: 6648,
+        identity: "f77ad768fd3d3f64",
+        data: { hello: "world", count: 42 },
+      };
+
+      const stringified = Data.stringify(block);
+      expect(stringified).toBe(
+        'b13b9e5e847936705e86dd4b7799:edb8c1afbf45558223119f87365a:TIM:TST:1769230455:4138e:f77ad768fd3d3f64:6648:{"hello":"world","count":42}',
+      );
+
+      const parsed = Data.parse(stringified);
+      expect(parsed).toEqual(block);
+    });
+
+    it("Does not include data separator when data is empty object", () => {
+      const block: Block = {
+        hash: "ffffb13b9e5e847936705e86dd4b7799",
+        previousHash: "ffffedb8c1afbf45558223119f87365a",
+        player: "TIM",
+        team: "TST",
+        timestamp: 1769230455,
+        nonce: 267150,
+        index: 6648,
+        identity: "f77ad768fd3d3f64",
+        data: {},
+      };
+
+      const stringified = Data.stringify(block);
+      // Should not include the 9th part when data is empty
+      expect(stringified).toBe(
+        "b13b9e5e847936705e86dd4b7799:edb8c1afbf45558223119f87365a:TIM:TST:1769230455:4138e:f77ad768fd3d3f64:6648",
+      );
+
+      const parsed = Data.parse(stringified);
+      // Should return empty object when parsing 8 parts
+      expect(parsed.data).toEqual({});
+    });
+
+    it("Throws error for invalid JSON in data part", () => {
+      const line =
+        "b13b9e5e847936705e86dd4b7799:edb8c1afbf45558223119f87365a:TIM:TST:1769230455:4138e:f77ad768fd3d3f64:6648:invalid-json";
+
+      expect(() => Data.parse(line)).toThrow(
+        "Invalid block format: data part is not valid JSON",
+      );
+    });
+
+    it.only("Throws error when data part is not an object", () => {
+      const line =
+        'b13b9e5e847936705e86dd4b7799:edb8c1afbf45558223119f87365a:TIM:TST:1769230455:4138e:f77ad768fd3d3f64:6648:["array","not","object"]';
+
+      expect(() => Data.parse(line)).toThrow(
+        "Invalid block format: data part is not valid JSON",
       );
     });
 
@@ -243,7 +328,8 @@ describe("Data", () => {
 
         expect(loadedChain).toHaveLength(5);
         for (let i = 0; i < testBlocks.length; i++) {
-          expect(loadedChain[i]).toEqual(testBlocks[i]);
+          // When parsing blocks without data, data should be set to {}
+          expect(loadedChain[i]).toEqual({ ...testBlocks[i], data: {} });
         }
 
         // Verify file content format
@@ -254,7 +340,8 @@ describe("Data", () => {
         // Verify each line can be parsed back
         for (let i = 0; i < lines.length; i++) {
           const parsed = Data.parse(lines[i]);
-          expect(parsed).toEqual(testBlocks[i]);
+          // When parsing blocks without data, data should be set to {}
+          expect(parsed).toEqual({ ...testBlocks[i], data: {} });
         }
       } finally {
         await rm(tempDir, { recursive: true, force: true });

--- a/server/src/game/game.ts
+++ b/server/src/game/game.ts
@@ -160,6 +160,7 @@ export class Game {
     identity: string;
     team: string;
     nonce: number;
+    data?: Record<string, unknown>;
   }): Promise<{ recent: Block[]; difficulty: string }> {
     const { team, previousHash, identity } = args;
     const isGenesisBlock = previousHash === Block.GENESIS_PREVIOUS_HASH;
@@ -182,6 +183,7 @@ export class Game {
           index: 0,
           timestamp: Timestamp.now(),
           identity,
+          data: args.data,
         };
 
         const error = Chain.verifyGenesisBlock(newBlock);
@@ -200,7 +202,10 @@ export class Game {
         const teamChain = this.chains.get(team)!;
 
         // Create the new block
-        newBlock = Chain.verifyIncomingBlock(args, teamChain);
+        newBlock = Chain.verifyIncomingBlock(
+          { ...args, data: args.data },
+          teamChain,
+        );
 
         // Append to chain and persist to data layer
         await this.appendBlock(newBlock, teamChain, team);

--- a/server/src/server/schemas.ts
+++ b/server/src/server/schemas.ts
@@ -285,6 +285,10 @@ export const schemas = {
           identity: schemaRefs.identity,
           nonce: schemaRefs.nonce,
           hash: schemaRefs.hashCode,
+          data: {
+            type: "object",
+            additionalProperties: true,
+          },
         },
         required: ["previousHash", "player", "identity", "nonce", "hash"],
         additionalProperties: false,
@@ -305,6 +309,10 @@ export const schemas = {
                   nonce: schemaRefs.nonce,
                   hash: schemaRefs.hashCode,
                   previousHash: schemaRefs.hashCode,
+                  data: {
+                    type: "object",
+                    additionalProperties: true,
+                  },
                 },
                 required: [
                   "index",

--- a/server/src/server/server.test.ts
+++ b/server/src/server/server.test.ts
@@ -176,4 +176,147 @@ describe("Server", () => {
       },
     ]);
   });
+
+  describe("POST /api/teams/:team/chain - data field validation", () => {
+    test("Accepts valid object for data field", async (context) => {
+      context.mock.method(game, "submitBlock", async () => ({
+        recent: [],
+        difficulty: "ffff0000000000000000000000000000",
+      }));
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/teams/TST/chain",
+        payload: {
+          previousHash: "ffffffffffffffffffffffffffffffff",
+          player: "AAA",
+          identity: "b989bcb4a39c769d",
+          nonce: 1,
+          hash: "ffff0000000000000000000000000000",
+          data: { hello: "world", count: 42 },
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    test("Rejects array for data field", async () => {
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/teams/TST/chain",
+        payload: {
+          previousHash: "ffffffffffffffffffffffffffffffff",
+          player: "AAA",
+          identity: "b989bcb4a39c769d",
+          nonce: 1,
+          hash: "ffff0000000000000000000000000000",
+          data: ["array", "not", "object"],
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = response.json();
+      expect(body).toHaveProperty("validationErrors");
+    });
+
+    test("Rejects string for data field", async () => {
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/teams/TST/chain",
+        payload: {
+          previousHash: "ffffffffffffffffffffffffffffffff",
+          player: "AAA",
+          identity: "b989bcb4a39c769d",
+          nonce: 1,
+          hash: "ffff0000000000000000000000000000",
+          data: "not an object",
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = response.json();
+      expect(body).toHaveProperty("validationErrors");
+    });
+
+    test("Rejects null for data field", async () => {
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/teams/TST/chain",
+        payload: {
+          previousHash: "ffffffffffffffffffffffffffffffff",
+          player: "AAA",
+          identity: "b989bcb4a39c769d",
+          nonce: 1,
+          hash: "ffff0000000000000000000000000000",
+          data: null,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = response.json();
+      expect(body).toHaveProperty("validationErrors");
+    });
+
+    test("Rejects number for data field", async () => {
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/teams/TST/chain",
+        payload: {
+          previousHash: "ffffffffffffffffffffffffffffffff",
+          player: "AAA",
+          identity: "b989bcb4a39c769d",
+          nonce: 1,
+          hash: "ffff0000000000000000000000000000",
+          data: 123,
+        },
+      });
+
+      expect(response.statusCode).toBe(400);
+      const body = response.json();
+      expect(body).toHaveProperty("validationErrors");
+    });
+
+    test("Accepts empty object for data field", async (context) => {
+      context.mock.method(game, "submitBlock", async () => ({
+        recent: [],
+        difficulty: "ffff0000000000000000000000000000",
+      }));
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/teams/TST/chain",
+        payload: {
+          previousHash: "ffffffffffffffffffffffffffffffff",
+          player: "AAA",
+          identity: "b989bcb4a39c769d",
+          nonce: 1,
+          hash: "ffff0000000000000000000000000000",
+          data: {},
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+
+    test("Accepts request without data field", async (context) => {
+      context.mock.method(game, "submitBlock", async () => ({
+        recent: [],
+        difficulty: "ffff0000000000000000000000000000",
+      }));
+
+      const response = await server.inject({
+        method: "POST",
+        url: "/api/teams/TST/chain",
+        payload: {
+          previousHash: "ffffffffffffffffffffffffffffffff",
+          player: "AAA",
+          identity: "b989bcb4a39c769d",
+          nonce: 1,
+          hash: "ffff0000000000000000000000000000",
+        },
+      });
+
+      expect(response.statusCode).toBe(200);
+    });
+  });
 });

--- a/server/src/server/server.ts
+++ b/server/src/server/server.ts
@@ -246,12 +246,14 @@ export function createServer(
           nonce: number;
           identity: string;
           hash: string;
+          data?: Record<string, unknown>;
         };
       }>,
       reply: FastifyReply,
     ) => {
       const { team } = request.params;
-      const { previousHash, player, nonce, identity, hash } = request.body;
+      const { previousHash, player, nonce, identity, hash, data } =
+        request.body;
 
       const derivedIdentity = IdentityController.generateDerivedIdentityToken({
         identityToken: identity,
@@ -265,6 +267,7 @@ export function createServer(
         nonce,
         identity: derivedIdentity,
         hash,
+        data,
       });
 
       return reply.status(200).send({

--- a/webui/src/api/api.types.d.ts
+++ b/webui/src/api/api.types.d.ts
@@ -57,6 +57,7 @@ export type SubmitBlockAPIRequest = {
   nonce: number;
   hash: string;
   message?: string;
+  data?: Record<string, unknown>;
 };
 
 export type Block = {
@@ -68,4 +69,5 @@ export type Block = {
   hash: string;
   previousHash: string;
   message?: string;
+  data?: Record<string, unknown>;
 };


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds an optional JSON `data` payload to blocks and wires it through storage, validation, and APIs.
> 
> - Extends `Block` type and `Chain.verifyIncomingBlock`/`Game.submitBlock` to carry optional `data`
> - Persists `data` in `Data.stringify`/`parse` as a 9th colon-delimited part when non-empty; defaults to `{}` when absent; validates JSON object
> - Updates `POST /api/teams/:team/chain` schema and handler to accept/pass through `data` and include it in responses
> - Updates web UI API types to include optional `data` on `SubmitBlockAPIRequest` and `Block`
> - Adds tests for parsing/stringifying with/without `data`, JSON validation errors, and server request validation
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6de112f367c7a947295dbe91b8a5e187a19d217e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->